### PR TITLE
fix: maximum height of the popper

### DIFF
--- a/components/RuleItem.vue
+++ b/components/RuleItem.vue
@@ -62,7 +62,7 @@ function capitalize(str?: string) {
         @click="e => emit('badgeClick', e)"
       />
       <template #popper>
-        <div>
+        <div max-h="50vh">
           <div flex="~ items-center gap-2" p3>
             <NuxtLink
               action-button


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
If there are too many rules such as `jsonc/sort-keys`, the height will be too heigh.
<img width="1411" alt="image" src="https://github.com/antfu/eslint-flat-config-viewer/assets/61053131/bc1f1572-80ae-4041-9bd3-6c699ee53fd6">
add `max-h="50vh"`
<img width="1411" alt="image" src="https://github.com/antfu/eslint-flat-config-viewer/assets/61053131/6b09615c-c5a9-4df1-bbb6-e3fdee04aee7">


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
