### PR TITLE
feat(ui): convert rules to card layout for better readability

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -26,7 +26,7 @@ await ensureDataFetch()
       only works with the <a href="https://eslint.org/docs/latest/use/configure/configuration-files-new" target="_blank" font-bold hover:underline>new flat config format</a>.
     </div>
   </div>
-  <div v-else px14 py10>
+  <div v-else px2 py10 md:px14>
     <NavBar />
     <NuxtPage />
   </div>

--- a/components/ColorizedRuleName.vue
+++ b/components/ColorizedRuleName.vue
@@ -38,11 +38,17 @@ const parsed = computed(() => {
 <template>
   <component
     :is="as || 'div'"
-    ws-nowrap rounded bg-gray:5 px2 font-mono
-    border="~ base"
+    ws-nowrap rounded px2 font-semibold font-mono op-80
   >
-    <span v-if="parsed.scope" :style="{ color: getPluginColor(parsed.scope) }">{{ parsed.scope }}</span>
-    <span v-if="parsed.scope" op30>/</span>
-    <span op75>{{ parsed.name }}</span>
+    <div class="group" pos-relative truncate text-lg>
+      <span v-if="parsed.scope" :style="{ color: getPluginColor(parsed.scope) }">{{ parsed.scope }}</span>
+      <span v-if="parsed.scope" op50>/</span>
+      <span op-90 transition group-hover:op-100>{{ parsed.name }}</span>
+      <div
+        group-hover="op-50" pos-absolute bottom-1
+        z--1 h-1 w-full bg-gray-600 op-30 transition-all
+        :style="{ backgroundColor: parsed.scope && getPluginColor(parsed.scope) }"
+      />
+    </div>
   </component>
 </template>

--- a/components/ConfigItem.vue
+++ b/components/ConfigItem.vue
@@ -70,46 +70,48 @@ function gotoPlugin(name: string) {
           </div>
         </div>
       </div>
-      <div v-else-if="config.rules">
-        <div flex="~ gap-2 items-center">
+      <div v-else-if="config.rules" flex="~ col gap-2">
+        <div flex gap-2>
           <div i-carbon-list-checked my1 flex-none />
-          <div>Rules</div>
-        </div>
-        <div grid="~ cols-[max-content_max-content_max-content_1fr] gap-x-2 items-center">
-          <template
-            v-for="value, name in config.rules"
-            :key="name"
-          >
-            <RuleItem
-              v-if="!(filters?.rule) || filters.rule === name"
-              :rule="getRule(name) || { name }"
-              :value="value"
-              :class="getRuleLevel(value) === 'off' ? 'op50' : ''"
-            >
-              <template #popup>
-                <RuleStateItem
-                  border="t base"
-                  :is-local="true"
-                  :state="{
-                    name,
-                    level: getRuleLevel(value)!,
-                    configIndex: index,
-                    options: getRuleOptions(value),
-                  }"
-                />
-              </template>
-              <template #popup-actions>
-                <button
-                  v-close-popper
-                  action-button
-                  @click="emit('badgeClick', name)"
+          <div flex="~ col gap-2" w-full>
+            <div>Rules</div>
+            <div grid="~ cols-1 gap-x-3 gap-y-3 items-center" lg="grid-cols-2" xl="grid-cols-3">
+              <template
+                v-for="value, name in config.rules"
+                :key="name"
+              >
+                <RuleItem
+                  v-if="!(filters?.rule) || filters.rule === name"
+                  :rule="getRule(name) || { name }"
+                  :value="value"
+                  :class="getRuleLevel(value) === 'off' ? 'op50' : ''"
                 >
-                  <div i-carbon-filter />
-                  Filter by this rule
-                </button>
+                  <template #popup>
+                    <RuleStateItem
+                      border="t base"
+                      :is-local="true"
+                      :state="{
+                        name,
+                        level: getRuleLevel(value)!,
+                        configIndex: index,
+                        options: getRuleOptions(value),
+                      }"
+                    />
+                  </template>
+                  <template #popup-actions>
+                    <button
+                      v-close-popper
+                      action-button
+                      @click="emit('badgeClick', name)"
+                    >
+                      <div i-carbon-filter />
+                      Filter by this rule
+                    </button>
+                  </template>
+                </RuleItem>
               </template>
-            </RuleItem>
-          </template>
+            </div>
+          </div>
         </div>
         <div>
           <button v-if="filters?.rule" ml8 op50 @click="emit('badgeClick', '')">

--- a/components/ConfigItem.vue
+++ b/components/ConfigItem.vue
@@ -75,7 +75,7 @@ function gotoPlugin(name: string) {
           <div i-carbon-list-checked my1 flex-none />
           <div flex="~ col gap-2" w-full>
             <div>Rules</div>
-            <div grid="~ cols-1 gap-x-3 gap-y-3 items-center" lg="grid-cols-2" xl="grid-cols-3">
+            <div grid="~ cols-1 gap-x-3 gap-y-3 items-center">
               <template
                 v-for="value, name in config.rules"
                 :key="name"

--- a/components/RuleItem.vue
+++ b/components/RuleItem.vue
@@ -23,7 +23,7 @@ function capitalize(str?: string) {
 </script>
 
 <template>
-  <div pos-relative rounded bg-secondary p-4 pt-3>
+  <div pos-relative rounded bg-gray:5 p-3 pr-2 pt-2>
     <div flex="~" w-full items-center justify-between>
       <div :class="props.class" min-w-0 flex-1>
         <VDropdown max-w-fit>
@@ -76,7 +76,7 @@ function capitalize(str?: string) {
           </template>
         </div>
 
-        <div v-if="rule.fixable || value != null" flex="~" gap-2 :class="props.class">
+        <div v-if="rule.fixable || value != null" flex="~" gap-1 :class="props.class">
           <div v-if="rule.fixable" title="Fixable" i-carbon-ibm-toolchain op40 />
           <div v-if="value != null">
             <div
@@ -84,7 +84,7 @@ function capitalize(str?: string) {
               title="Enabled as 'error'"
             />
             <div
-              v-if="getRuleLevel(value) === 'warn'" i-carbon-warning-alt-filled text-amber op30
+              v-if="getRuleLevel(value) === 'warn'" i-carbon-checkmark-filled text-yellow op50
               title="Enabled as 'warn'"
             />
             <div

--- a/components/RuleItem.vue
+++ b/components/RuleItem.vue
@@ -24,8 +24,8 @@ function capitalize(str?: string) {
 
 <template>
   <div pos-relative rounded bg-gray:5 p-3 pr-2 pt-2>
-    <div flex="~" w-full items-center justify-between>
-      <div :class="props.class" min-w-0 flex-1>
+    <div flex="~" w-full items-center>
+      <div :class="props.class" min-w-0>
         <VDropdown max-w-fit>
           <ColorizedRuleName
             :name="rule.name"
@@ -61,7 +61,7 @@ function capitalize(str?: string) {
         </VDropdown>
       </div>
 
-      <div flex="~" items-center self-start gap-1>
+      <div flex="~" items-center gap-1>
         <div v-if="ruleStates" flex="~ items-center gap-1 justify-end" text-lg>
           <template v-for="s, idx of ruleStates" :key="idx">
             <VDropdown>

--- a/components/RuleItem.vue
+++ b/components/RuleItem.vue
@@ -23,78 +23,83 @@ function capitalize(str?: string) {
 </script>
 
 <template>
-  <div v-if="ruleStates" flex="~ items-center gap-0.5 justify-end" text-lg>
-    <template v-for="s, idx of ruleStates" :key="idx">
-      <VDropdown>
-        <RuleLevelIcon
-          :level="s.level"
-          :config-index="s.configIndex"
-        />
-        <template #popper>
-          <RuleStateItem :state="s" />
-        </template>
-      </VDropdown>
-    </template>
-  </div>
+  <div pos-relative rounded bg-secondary p-4 pt-3>
+    <div flex="~" w-full items-center justify-between>
+      <div :class="props.class" min-w-0 flex-1>
+        <VDropdown max-w-fit>
+          <ColorizedRuleName
+            :name="rule.name"
+            :prefix="rule.plugin"
+            as="button"
+            mb-.5 max-w-full
+            @click="e => emit('badgeClick', e)"
+          />
+          <template #popper>
+            <div>
+              <div flex="~ items-center gap-2" p3>
+                <NuxtLink
+                  action-button
+                  :to="rule.docs?.url" target="_blank" rel="noopener noreferrer"
+                  title="Documentations"
+                >
+                  <div i-carbon-launch />
+                  Documentations
+                </NuxtLink>
+                <button
+                  action-button
+                  title="Copy"
+                  @click="copy(rule.name)"
+                >
+                  <div i-carbon-copy />
+                  Copy name
+                </button>
+                <slot name="popup-actions" />
+              </div>
+              <slot name="popup" />
+            </div>
+          </template>
+        </VDropdown>
+      </div>
 
-  <div v-if="value != null" :class="props.class">
-    <div
-      v-if="getRuleLevel(value) === 'error'" i-carbon-warning-filled text-green op0
-      title="Enabled as 'error'"
-    />
-    <div
-      v-if="getRuleLevel(value) === 'warn'" i-carbon-warning-alt-filled text-amber op30
-      title="Enabled as 'warn'"
-    />
-    <div
-      v-if="getRuleLevel(value) === 'off'" i-carbon-error-outline text-gray op50
-      title="Turned off"
-    />
-  </div>
-
-  <div :class="props.class">
-    <VDropdown inline-block>
-      <ColorizedRuleName
-        m1
-        :name="rule.name"
-        :prefix="rule.plugin"
-        as="button"
-        @click="e => emit('badgeClick', e)"
-      />
-      <template #popper>
-        <div>
-          <div flex="~ items-center gap-2" p3>
-            <NuxtLink
-              action-button
-              :to="rule.docs?.url" target="_blank" rel="noopener noreferrer"
-              title="Documentations"
-            >
-              <div i-carbon-launch />
-              Documentations
-            </NuxtLink>
-            <button
-              action-button
-              title="Copy"
-              @click="copy(rule.name)"
-            >
-              <div i-carbon-copy />
-              Copy name
-            </button>
-            <slot name="popup-actions" />
-          </div>
-          <slot name="popup" />
+      <div flex="~" items-center self-start gap-1>
+        <div v-if="ruleStates" flex="~ items-center gap-1 justify-end" text-lg>
+          <template v-for="s, idx of ruleStates" :key="idx">
+            <VDropdown>
+              <RuleLevelIcon
+                :level="s.level"
+                :config-index="s.configIndex"
+              />
+              <template #popper>
+                <RuleStateItem :state="s" />
+              </template>
+            </VDropdown>
+          </template>
         </div>
-      </template>
-    </VDropdown>
-  </div>
 
-  <div>
-    <div v-if="rule.fixable" title="Fixable" i-carbon-ibm-toolchain mx2 op50 />
-  </div>
+        <div v-if="rule.fixable || value != null" flex="~" gap-2 :class="props.class">
+          <div v-if="rule.fixable" title="Fixable" i-carbon-ibm-toolchain op40 />
+          <div v-if="value != null">
+            <div
+              v-if="getRuleLevel(value) === 'error'" i-carbon-checkmark-filled text-green op80
+              title="Enabled as 'error'"
+            />
+            <div
+              v-if="getRuleLevel(value) === 'warn'" i-carbon-warning-alt-filled text-amber op30
+              title="Enabled as 'warn'"
+            />
+            <div
+              v-if="getRuleLevel(value) === 'off'" i-carbon-error-outline text-gray op50
+              title="Turned off"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
 
-  <div :class="props.class">
-    <div of-hidden text-ellipsis op75>
-      {{ capitalize(rule.docs?.description) }}
+    <div :class="props.class">
+      <div ms-2 of-hidden truncate text-ellipsis text-sm op40>
+        {{ capitalize(rule.docs?.description) || 'No description found' }}
+      </div>
     </div>
   </div>
 </template>

--- a/components/RuleLevelIcon.vue
+++ b/components/RuleLevelIcon.vue
@@ -15,7 +15,7 @@ const title = computed(() => {
 
 <template>
   <div
-    v-if="level === 'error'" i-carbon-warning-filled text-green op80
+    v-if="level === 'error'" i-carbon-checkmark-filled text-green op80
     :title="title"
   />
   <div

--- a/components/RuleLevelIcon.vue
+++ b/components/RuleLevelIcon.vue
@@ -19,7 +19,7 @@ const title = computed(() => {
     :title="title"
   />
   <div
-    v-if="level === 'warn'" i-carbon-warning-alt-filled text-lime op80
+    v-if="level === 'warn'" i-carbon-checkmark-filled text-yellow
     :title="title"
   />
   <div

--- a/components/RuleStateItem.vue
+++ b/components/RuleStateItem.vue
@@ -70,7 +70,7 @@ function goto() {
           Rule options
         </div>
       </div>
-      <pre rounded bg-secondary p2 text-sm>{{ state.options }}</pre>
+      <pre rounded bg-secondary p2 text-sm font-mono>{{ state.options }}</pre>
     </template>
   </div>
 </template>

--- a/pages/rules.vue
+++ b/pages/rules.vue
@@ -65,7 +65,7 @@ const filtered = computed(() => {
     <div op50>
       {{ filtered.length }} rules available
     </div>
-    <div my4 grid="~ cols-1 items-center" gap-x-3 gap-y-3 lg="grid-cols-2" xl="grid-cols-3">
+    <div my4 grid="~ cols-1 items-center" gap-x-3 gap-y-3>
       <RuleItem
         v-for="rule in filtered"
         :key="rule.name"

--- a/pages/rules.vue
+++ b/pages/rules.vue
@@ -65,7 +65,7 @@ const filtered = computed(() => {
     <div op50>
       {{ filtered.length }} rules available
     </div>
-    <div my4 grid="~ cols-[max-content_max-content_max-content_1fr] gap-x-2 items-center">
+    <div my4 grid="~ cols-1 items-center" gap-x-3 gap-y-3 lg="grid-cols-2" xl="grid-cols-3">
       <RuleItem
         v-for="rule in filtered"
         :key="rule.name"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR introduces a new card-style layout for rule descriptions.

The aim is to enhance the readability and visual appeal of the rules.

The changes include a UI overhaul of the rule description section and updated screenshots for comparison.

This PR also includes partial adaptation for mobile, and I can continue to support this in subsequent PRs.

### Linked Issues

- No linked issues as this is a UI enhancement without a prior issue.

### Additional context

The main focus of this PR is the UI change for better clarity when viewing rules. Here are some screenshots for comparison.

Before:
<img width="1199" alt="271454257-f386563a-c655-458e-a2c3-0af19ebec958" src="https://github.com/antfu/eslint-flat-config-viewer/assets/75012451/3fa1717d-64c7-4514-92e4-93492dc9aeee">

After:
<img width="1373" alt="after" src="https://github.com/antfu/eslint-flat-config-viewer/assets/75012451/ac63e4f6-c717-4d93-a9dc-0843c7672b84">
<img width="1373" alt="Dark Mode" src="https://github.com/antfu/eslint-flat-config-viewer/assets/75012451/fa42f83f-d7ef-440c-b016-d27e1a96d0a5">

Before:
<img width="1238" alt="Light Mode: Before" src="https://github.com/antfu/eslint-flat-config-viewer/assets/75012451/6d916c78-d2e7-4c3a-ab1e-ad3a238c16c3">

After:
<img width="1239" alt="2023-11-12 00 36 16" src="https://github.com/antfu/eslint-flat-config-viewer/assets/75012451/bc314fce-23eb-4ffe-ae8e-15848f8f7f20">

Mobile Before:
![IMG_0385](https://github.com/antfu/eslint-flat-config-viewer/assets/75012451/e9c366d4-1fc6-441e-afdb-f4dc409951ad)

Mobile After:
![IMG_0387](https://github.com/antfu/eslint-flat-config-viewer/assets/75012451/d7e21637-99da-41f3-869a-10d35d3a1b3b)


![IMG_0389](https://github.com/antfu/eslint-flat-config-viewer/assets/75012451/f53948df-6873-4800-ac6a-987c2fa21d4f)


